### PR TITLE
Laravel 5.5 - GenerateCommand::handle() does not exist 

### DIFF
--- a/src/Spekkionu/Assetcachebuster/Console/GenerateCommand.php
+++ b/src/Spekkionu/Assetcachebuster/Console/GenerateCommand.php
@@ -52,9 +52,9 @@ class GenerateCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
-        $this->line('Generating new asset hash. Environment: <comment>'.$this->laravel->make('env').'</comment>');
+        $this->line('Generating new asset hash. Environment: <comment>' . $this->laravel->make('env') . '</comment>');
 
         $hash = $this->hashReplacer->replaceHash();
 
@@ -63,4 +63,5 @@ class GenerateCommand extends Command
         $msg = "New hash {$hash} generated.";
         $this->info($msg);
     }
+
 }


### PR DESCRIPTION
After upgrading to laravel 5.5 artisan assetcachebuster:generate; causes the follow error.

[ReflectionException]                                                        
Method Spekkionu\Assetcachebuster\Console\GenerateCommand::handle() does not exist.

The method fire was deprecated in Laravel 5.1, until Laravel 5.4 it was keeping retrocompatibility but on 5.5 it only allow handle.

